### PR TITLE
fix(bento): avoid hydration mismatch in Mastodon date formatting

### DIFF
--- a/src/components/bento/MastodonSection.tsx
+++ b/src/components/bento/MastodonSection.tsx
@@ -11,15 +11,21 @@ interface MastodonSectionProps {
   layout?: "sidebar" | "carousel";
 }
 
+// Format a date deterministically in Asia/Tokyo so server-side rendering
+// (Vercel is UTC) and client-side hydration produce identical strings.
+// Using toLocaleDateString here caused React hydration mismatch (#418)
+// because the server and browser disagreed on the rendered time zone.
 function formatDate(dateStr: string): string {
   const date = new Date(dateStr);
-  return date.toLocaleDateString("ja-JP", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  // Shift to JST (UTC+9) by adding 9 hours to the UTC timestamp, then read
+  // the UTC fields of the shifted date to avoid runtime time zone differences.
+  const jst = new Date(date.getTime() + 9 * 60 * 60 * 1000);
+  const year = jst.getUTCFullYear();
+  const month = jst.getUTCMonth() + 1;
+  const day = jst.getUTCDate();
+  const hour = String(jst.getUTCHours()).padStart(2, "0");
+  const minute = String(jst.getUTCMinutes()).padStart(2, "0");
+  return `${year}年${month}月${day}日 ${hour}:${minute}`;
 }
 
 function decodeEntities(text: string): string {


### PR DESCRIPTION
## Summary

Fixes the production bug where the Mastodon sidebar on https://touyou.dev/bento was empty after merging #40. React was throwing minified error #418 (hydration mismatch) and unmounting the Suspense boundary, so nothing rendered.

## Root cause

`formatDate` used `toLocaleDateString(\"ja-JP\", { hour: \"2-digit\", minute: \"2-digit\", ... })`. That function honors the ambient time zone:

- **Vercel server (SSR)**: runs in UTC → rendered `2026年4月8日 7:45`
- **Browser (Asia/Tokyo)**: → rendered `2026年4月8日 16:45`

SSR HTML and client hydration didn't match, React #418 fired, and the whole Mastodon tree was discarded.

## Fix

Replace the `toLocaleDateString` call with a deterministic formatter that:
1. Adds 9 hours to the UTC timestamp to shift it to JST.
2. Reads the shifted date with `getUTC*` methods (ignoring the runtime's local time zone entirely).
3. Builds the string manually as `\`\${year}年\${month}月\${day}日 \${HH}:\${MM}\``.

Verified that `TZ=UTC node` and `TZ=Asia/Tokyo node` both produce `2026年4月8日 16:45` for the same input, so SSR and hydration will agree.

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm lint` clean
- [x] Manually verified identical output between UTC and Asia/Tokyo runtimes
- [ ] After merge: confirm Mastodon feed renders on https://touyou.dev/bento

🤖 Generated with [Claude Code](https://claude.com/claude-code)